### PR TITLE
remove whitespace inside the textarea tag

### DIFF
--- a/templates/edit.goml
+++ b/templates/edit.goml
@@ -6,8 +6,7 @@
     <h1>Edit Note</h1>
     <form action="/notes/update/{{.Id}}" method="post">
         <p>Title:<br> <input type="text" value="{{.Note.Title}}" name="title"></p>
-        <p>Description:<br> <textarea rows="4" cols="50" name="description">
-        {{.Note.Description}}</textarea> </p>
+        <p>Description:<br> <textarea rows="4" cols="50" name="description">{{.Note.Description}}</textarea> </p>
         <p><input type="submit" value="submit"/></p>
     </form>
 {{end}}


### PR DESCRIPTION
This whitespace is added to the description each edit and save.